### PR TITLE
fix: use node v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/mikecao/umami.git"
   },
+  "engines": {
+    "node": "^16.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "npm-run-all build-tracker build-lang build-geo build-db build-app db-push",


### PR DESCRIPTION
## Why

Umami uses a crypto method removed in node v17+ meaning when buildpack goes to build the image `Error: error:0308010C:digital envelope routines::unsupported` is thrown crashing the build process.